### PR TITLE
Fix rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,9 @@ Style/AsciiComments:
 Style/Documentation:
   Enabled: false
 
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
 Style/RedundantReturn:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,18 +12,20 @@ Layout/SpaceInsideArrayLiteralBrackets:
 Style/AsciiComments:
   Enabled: false
 
-Style/RedundantReturn:
-  Enabled: false
-
 Style/Documentation:
   Enabled: false
 
-Metrics/LineLength:
-  Max: 150
-Metrics/MethodLength:
-  Max: 30
+Style/RedundantReturn:
+  Enabled: false
+
 Metrics/BlockLength:
   Exclude:
     - spec/**/*_spec.rb
     - spec/factories/*
     - spec/support/*
+
+Metrics/LineLength:
+  Max: 150
+
+Metrics/MethodLength:
+  Max: 30

--- a/app/controllers/sample_controller.rb
+++ b/app/controllers/sample_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SampleController < ApplicationController
   def index
   end


### PR DESCRIPTION
`rubocop` の設定の追加
- 空のメソッドを複数行で書くことを許可するように変更