### PR TITLE
Delete unnecessary assets:precompile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,6 @@ jobs:
       - run:
           name: Compile Assets
           command: |
-            bin/rails assets:precompile
             bin/rails webpacker:compile
 
       - run:


### PR DESCRIPTION
#48 
sprockets を使用しなくなったので、`assets:precompile` を CircleCI の処理から削除する。