### PR TITLE
Ignore directory for active storage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 .git/
 node_modules/
+storage/
+tmp/storage


### PR DESCRIPTION
active sotrage ではamazon S3を使用するので、storage 関連のファイルは不要。
ローカルで開発中に一部local storage を使用したので、`.dockerignore` に追加しておく。