### PR TITLE
Add port for puma

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -14,6 +14,7 @@ threads min_threads_count, max_threads_count
 #
 environment ENV.fetch('RAILS_ENV') { 'development' }
 
+port ENV.fetch('PORT') { 3000 }
 app_root = File.expand_path('..', __dir__)
 bind "unix://#{app_root}/tmp/sockets/puma.sock"
 


### PR DESCRIPTION
port 指定がないとややこしい（ECS の設定では3000番のポートに接続するように設定している）ので、port 番号を指定する。