### PR TITLE
Fix docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,10 @@ COPY package.json yarn.lock babel.config.js postcss.config.js ./
 RUN yarn install
 
 ARG RAILS_ENV
+ENV RAILS_ENV $RAILS_ENV
+
+ARG RAILS_MASTER_KEY
+ENV RAILS_MASTER_KEY $RAILS_MASTER_KEY
 
 COPY . /webapp
 RUN set -x \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   app:
     build:
       context: .
-      dockerfile: docker/app/Dockerfile
+      dockerfile: Dockerfile
     tty: true
     stdin_open: true
     volumes:


### PR DESCRIPTION
#117 

以下の解消のため。

```
bin/rails webpacker:clobber
rails aborted!
ArgumentError: Missing `secret_key_base` for 'production' environment, set this string with `rails credentials:edit`
```