### PR TITLE
Fix circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,4 +109,4 @@ workflows:
           family: '${AWS_RESOURCE_NAME_PREFIX}'
           service-name: '${AWS_RESOURCE_NAME_PREFIX}-service'
           cluster-name: '${AWS_RESOURCE_NAME_PREFIX}-cluster'
-          container-image-name-updates: 'container=nginx,tag=${CIRCLE_SHA1},container=rails,tag=${CIRCLE_SHA1}'
+          container-image-name-updates: 'container=rails,tag=${CIRCLE_SHA1},container=nginx,tag=${CIRCLE_SHA1}'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,5 +107,6 @@ workflows:
               only:
                 - master
           family: '${AWS_RESOURCE_NAME_PREFIX}'
+          service-name: '${AWS_RESOURCE_NAME_PREFIX}-service'
           cluster-name: '${AWS_RESOURCE_NAME_PREFIX}-cluster'
           container-image-name-updates: 'container=nginx,tag=${CIRCLE_SHA1},container=rails,tag=${CIRCLE_SHA1}'


### PR DESCRIPTION
#117 

以下のエラーの修正。

```
#!/bin/bash -eo pipefail
set -o noglob
DEPLOYMENT_CONTROLLER="$(echo ECS)"

if [ "${DEPLOYMENT_CONTROLLER}" = "CODE_DEPLOY" ]; then
    DEPLOYED_REVISION="${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}"
    DEPLOYMENT_ID=$(aws deploy create-deployment \
        --application-name "" \
        --deployment-group-name "" \
        --revision "{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"\\\", \\\"ContainerPort\\\": 80}}}}]}\"}}" \
        --query deploymentId)
    echo "Created CodeDeploy deployment: $DEPLOYMENT_ID"
else
  SERVICE_NAME="$(echo )"

  if [ -z "${SERVICE_NAME}" ]; then
      SERVICE_NAME="$(echo ${AWS_RESOURCE_NAME_PREFIX})"
  fi
  if [ "false" == "true" ]; then
      set -- "$@" --force-new-deployment
  fi
  DEPLOYED_REVISION=$(aws ecs update-service \
      --cluster "${AWS_RESOURCE_NAME_PREFIX}-cluster" \
      --service "${SERVICE_NAME}" \
      --task-definition "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
      --output text \
      --query service.taskDefinition \
      "$@")
fi
echo "export CCI_ORB_AWS_ECS_DEPLOYED_REVISION='${DEPLOYED_REVISION}'" >> $BASH_ENV

An error occurred (ServiceNotFoundException) when calling the UpdateService operation: 

Exited with code exit status 255
```