### PR TITLE
Update flash not to be displayed in render page

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -28,10 +28,8 @@ class BooksController < ApplicationController
       request = GoogleBooks::Request.new(params[:keyword])
       response = request.submit
       @books = response.found_books
-      if logged_in_user?
-        @books = @books.reject { |book| added_google_books_ids.include?(book.google_books_id) }
-        flash[:info] = I18n.t(:result_is_empty) unless @books.present?
-      end
+      @books = @books.reject { |book| added_google_books_ids.include?(book.google_books_id) } if logged_in_user?
+      flash.now[:info] = I18n.t(:result_is_empty) if @books.blank?
     else
       @books = []
     end


### PR DESCRIPTION
検索ページのフラッシュメッセージが、書籍が見つかった場合でも表示され続けてしまうので修正する。

![image](https://user-images.githubusercontent.com/29705494/77260428-50eb9a00-6ccb-11ea-887e-7e77e49716c4.png)
